### PR TITLE
chore: Use MAX instead max_value

### DIFF
--- a/src/bitline.rs
+++ b/src/bitline.rs
@@ -294,7 +294,7 @@ macro_rules! impl_Bitline {
             }
             #[inline]
             fn as_full() -> Self {
-                Self::max_value()
+                Self::MAX
             }
             #[inline]
             fn by_range(begin: usize, end: usize) -> Self {


### PR DESCRIPTION
- max_value is a legacy numeric method. It is recommended to use MAX instead. (clippy)
  https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
