### PR TITLE
Implement bit-reversal permutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ https://docs.rs/bittersweet/latest/bittersweet/bitline/trait.Bitline.html
 - `right_rotate`
 - `bin_to_gray_code`
 - `gray_code_to_bin`
+- `bit_reversal_permutation_to_bin`
+- `bin_to_bit_reversal_permutation`
 
 ## License
 


### PR DESCRIPTION
- Bit-reversal permutation
  - This is useful for bit-reversal permutation in FFT.
  - Also useful for pseudo-random shuffling order of bits.
  - https://en.wikipedia.org/wiki/Bit-reversal_permutation
