### PR TITLE
Remove Codecov upload from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,13 +71,3 @@ jobs:
       - run: |
           cargo install cargo-llvm-cov || true
           cargo llvm-cov --lcov --output-path coverage.lcov
-
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.lcov
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false
-          verbose: true


### PR DESCRIPTION
Remove the Codecov upload step now that coverage is reported via Octocov.