### PR TITLE
Use Octocov updatePrevious for PR comments

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -14,6 +14,7 @@ diff:
     - artifact://${GITHUB_REPOSITORY}
 comment:
   if: is_pull_request
+  updatePrevious: true
 report:
   if: is_default_branch
   datastores:


### PR DESCRIPTION
## Summary
- enable `comment.updatePrevious` in `.octocov.yml`
- prefer updating the existing Octocov PR comment instead of posting a new one

## Testing
- not run (config-only change)