### PR TITLE
ci: add minimal permissions to crates publish workflow

### DIFF
--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -1,5 +1,8 @@
 name: publish crates
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -9,6 +12,8 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` at workflow and publish job levels in `cratesio-publish.yml`.
- Keep publish dry-run/release conditions unchanged; only scope reduction was applied.

## Verification
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
