### PR TITLE
Pin crates publish workflow actions

### DIFF
--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -16,9 +16,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --release --all-features
 
       - name: publish (dry-run)


### PR DESCRIPTION
## Summary

- Pin the action references in the crates.io publish workflow to their currently resolved commit SHAs.
- Keep the existing release triggers, permissions, build step, and publish commands unchanged.

## Validation

- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cratesio-publish.yml"); puts "yaml ok"'\n- actionlint .github/workflows/cratesio-publish.yml\n- cargo build --release --all-features\n- cargo test --all-features\n- cargo fmt -- --check\n- cargo clippy --all-features -- -D warnings\n\nNote: this does not run the crates.io publish or dry-run publish steps.