### PR TITLE
Guard bit access indexes

### DIFF
--- a/src/bitline/base.rs
+++ b/src/bitline/base.rs
@@ -395,6 +395,10 @@ pub trait Bitline {
     /// assert_eq!(bitline.access(3), true);
     /// assert_eq!(bitline.access(4), true);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than or equal to the bitline length.
     fn access(&self, index: usize) -> bool;
 
     /// Count how many times 0 appears up to the index (i-th) position.

--- a/src/bitline/uints.rs
+++ b/src/bitline/uints.rs
@@ -246,6 +246,7 @@ macro_rules! impl_Bitline {
 
             #[inline]
             fn access(&self, index: usize) -> bool {
+                assert!(index < Self::length(), "bit index out of range");
                 (*self & (1 << (Self::length() - index - 1))) != 0
             }
 
@@ -759,6 +760,12 @@ mod tests {
         assert!(!0b00001000_u8.access(5));
         assert!(!0b00001000_u8.access(6));
         assert!(!0b00001000_u8.access(7));
+    }
+
+    #[test]
+    #[should_panic(expected = "bit index out of range")]
+    fn test_access_panics_on_out_of_range_index() {
+        let _ = 0b00001000_u8.access(8);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add an explicit bounds check for `Bitline::access` indexes.
- Document the panic contract for out-of-range indexes.
- Cover the out-of-range case with a unit test.

## Verification
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `git diff --check`