### PR TITLE
Pin spellcheck workflow ref

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@b48db82eb82c1f469430bb981812e58aca61d5b5


### PR DESCRIPTION
## Summary
- Pin the reusable spellcheck workflow to a full commit SHA instead of the moving `main` ref.
- Keep the existing read-only spellcheck permissions unchanged.

## Validation
- `actionlint .github/workflows/spellcheck.yml`
- `git diff --check origin/main...HEAD`
- Verified the pinned workflow file resolves through the GitHub API.

## Notes
- No external issue is linked; this is a workflow dependency pinning change.
