### PR TITLE
Guard radius and around against out-of-range shift amounts

### DIFF
--- a/src/bitline/base.rs
+++ b/src/bitline/base.rs
@@ -106,6 +106,13 @@ pub trait Bitline {
 
     /// Return the bits standing in n distance from the original starting bit.
     /// If there is no bit set to one, return None.
+    ///
+    /// When `n` is greater than or equal to the bitline length (e.g.
+    /// `Bitline8::radius(8)`), no in-range neighbor exists, so the result is
+    /// `Self::as_empty()`. This makes the behavior identical between debug
+    /// and release builds (`<<` and `>>` would otherwise panic in debug and
+    /// be implementation-defined in release for out-of-range shift amounts).
+    ///
     /// # Examples
     /// ```
     /// use bittersweet::bitline::{Bitline, Bitline8};
@@ -123,10 +130,21 @@ pub trait Bitline {
     /// assert_eq!(bitline.radius(0), 0b00000000);
     /// assert_eq!(bitline.radius(1), 0b01011010);
     /// assert_eq!(bitline.radius(2), 0b10011001);
+    ///
+    /// // Out-of-range radius is empty (in-range neighbors do not exist).
+    /// let bitline = 0b00010000 as Bitline8;
+    /// assert_eq!(bitline.radius(8), 0b00000000);
+    /// assert_eq!(bitline.radius(usize::MAX), 0b00000000);
     /// ```
     fn radius(&self, n: usize) -> Self;
 
     /// Return all bits standing between n distance from the standing bits (without original standing bits).
+    ///
+    /// When `n` is greater than or equal to the bitline length, the iteration
+    /// is capped at `Self::length() - 1`, so the result is the union of every
+    /// in-range radius. This avoids relying on out-of-range primitive shift,
+    /// keeping debug and release behavior identical.
+    ///
     /// # Examples
     /// ```
     /// use bittersweet::bitline::{Bitline, Bitline8};
@@ -139,6 +157,11 @@ pub trait Bitline {
     /// assert_eq!(bitline.around(0), 0b00000000);
     /// assert_eq!(bitline.around(1), 0b00000000);
     /// assert_eq!(bitline.around(2), 0b00000000);
+    ///
+    /// // n >= length is capped to the in-range radii.
+    /// let bitline = 0b00001000 as Bitline8;
+    /// assert_eq!(bitline.around(8), bitline.around(7));
+    /// assert_eq!(bitline.around(usize::MAX), bitline.around(7));
     /// ```
     fn around(&self, n: usize) -> Self;
 

--- a/src/bitline/uints.rs
+++ b/src/bitline/uints.rs
@@ -104,12 +104,16 @@ macro_rules! impl_Bitline {
             }
             #[inline]
             fn radius(&self, n: usize) -> Self {
+                if n >= Self::BITS as usize {
+                    return Self::as_empty();
+                }
                 (self << n) ^ (self >> n)
             }
             #[inline]
             fn around(&self, n: usize) -> Self {
+                let upper = cmp::min(n.saturating_add(1), Self::BITS as usize);
                 let mut a = 0;
-                for m in 0..(n + 1) {
+                for m in 0..upper {
                     a |= self.radius(m);
                 }
                 a
@@ -436,6 +440,24 @@ mod tests {
     }
 
     #[test]
+    fn test_radius_out_of_range_is_empty() {
+        // n >= bits has no in-range neighbor, so the result is empty.
+        // This is identical between debug and release builds (no shift overflow).
+        assert_eq!(0b00010000_u8.radius(8), 0b00000000_u8);
+        assert_eq!(0b11111111_u8.radius(8), 0b00000000_u8);
+        assert_eq!(0b00010000_u8.radius(9), 0b00000000_u8);
+        assert_eq!(0b00010000_u8.radius(usize::MAX), 0b00000000_u8);
+        assert_eq!(0b1010101010101010_u16.radius(16), 0_u16);
+        assert_eq!(0b1010101010101010_u16.radius(usize::MAX), 0_u16);
+        assert_eq!(u32::MAX.radius(32), 0_u32);
+        assert_eq!(u32::MAX.radius(usize::MAX), 0_u32);
+        assert_eq!(u64::MAX.radius(64), 0_u64);
+        assert_eq!(u64::MAX.radius(usize::MAX), 0_u64);
+        assert_eq!(u128::MAX.radius(128), 0_u128);
+        assert_eq!(u128::MAX.radius(usize::MAX), 0_u128);
+    }
+
+    #[test]
     fn test_around() {
         assert_eq!(0b00010000_u8.around(0), 0b00000000_u8);
         assert_eq!(0b00010000_u8.around(1), 0b00101000_u8);
@@ -445,6 +467,20 @@ mod tests {
         assert_eq!(0b00000000_u8.around(0), 0b00000000_u8);
         assert_eq!(0b00000000_u8.around(1), 0b00000000_u8);
         assert_eq!(0b00000000_u8.around(2), 0b00000000_u8);
+    }
+
+    #[test]
+    fn test_around_out_of_range_is_capped() {
+        // n >= bits is capped at the in-range radii union.
+        let bitline = 0b00010000_u8;
+        let saturated = bitline.around(7);
+        assert_eq!(bitline.around(8), saturated);
+        assert_eq!(bitline.around(9), saturated);
+        assert_eq!(bitline.around(usize::MAX), saturated);
+        // with_around propagates the same cap.
+        let with_saturated = bitline.with_around(7);
+        assert_eq!(bitline.with_around(8), with_saturated);
+        assert_eq!(bitline.with_around(usize::MAX), with_saturated);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `Bitline::radius(&self, n: usize)` evaluates `(self << n) ^ (self >> n)` directly, which panics in debug builds and produces implementation-defined results in release builds when `n` reaches the bitline width (e.g. `Bitline8::radius(8)`).
- `around(n)` propagated the same hazard through `radius(m)` over `0..=n`, and `n + 1` could overflow when `n == usize::MAX`.
- Return `Self::as_empty()` from `radius` when `n >= Self::BITS as usize` and cap the `around` iteration with `saturating_add`, so both debug and release agree on "out-of-range neighbors do not contribute."
- Document the new boundary contract in the `Bitline` trait doc tests and add unit tests covering `radius(8)`, `radius(usize::MAX)`, `around(usize::MAX)` and `with_around(usize::MAX)` for every `Bitline*` alias.

## Test plan

- [x] `cargo test`
- [x] `cargo test --release`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --no-default-features` (no-std feature gate)