### PR TITLE
Guard rank and rank_range against out-of-range indices

### DIFF
--- a/src/bitline/base.rs
+++ b/src/bitline/base.rs
@@ -435,9 +435,14 @@ pub trait Bitline {
     /// assert_eq!(bitline.rank_0(2), 2);
     /// assert_eq!(bitline.rank_0(5), 3);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than the bitline length.
     fn rank_0(&self, index: usize) -> usize;
 
     /// Count how many times 1 appears up to the index (i-th) position.
+    ///
     /// # Examples
     /// ```
     /// use bittersweet::bitline::{Bitline, Bitline8};
@@ -452,6 +457,10 @@ pub trait Bitline {
     /// assert_eq!(bitline.rank_1(7), 4);
     /// assert_eq!(bitline.rank_1(8), 4);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than the bitline length.
     fn rank_1(&self, index: usize) -> usize;
 
     /// Count how many times specified bit appears up to the index (i-th) position.
@@ -477,6 +486,10 @@ pub trait Bitline {
     /// assert_eq!(bitline.rank_range_0(0, 3), 3);
     /// assert_eq!(bitline.rank_range_0(0, 4), 3);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `begin > end` or if `end` is greater than the bitline length.
     fn rank_range_0(&self, begin: usize, end: usize) -> usize;
 
     /// Count how many times 1 appears between the begin (i-th) and the end (j-th) positions.
@@ -490,6 +503,10 @@ pub trait Bitline {
     /// assert_eq!(bitline.rank_range_1(0, 4), 1);
     /// assert_eq!(bitline.rank_range_1(3, 5), 2);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `begin > end` or if `end` is greater than the bitline length.
     fn rank_range_1(&self, begin: usize, end: usize) -> usize;
 
     /// Count how many times specified bit appears between the begin (i-th) and the end (j-th) positions.

--- a/src/bitline/uints.rs
+++ b/src/bitline/uints.rs
@@ -256,12 +256,14 @@ macro_rules! impl_Bitline {
 
             #[inline]
             fn rank_0(&self, index: usize) -> usize {
+                assert!(index <= Self::length(), "bit index out of range");
                 let mask_range = !Self::by_range(0, index);
                 (*self | mask_range).count_zeros() as usize
             }
 
             #[inline]
             fn rank_1(&self, index: usize) -> usize {
+                assert!(index <= Self::length(), "bit index out of range");
                 let mask_range = !Self::by_range(0, index);
                 (*self & !mask_range).count_ones() as usize
             }
@@ -277,6 +279,8 @@ macro_rules! impl_Bitline {
 
             #[inline]
             fn rank_range_0(&self, begin: usize, end: usize) -> usize {
+                assert!(begin <= end, "inverted range: begin must be ≤ end");
+                assert!(end <= Self::length(), "end index out of range");
                 let mask_begin = Self::by_range(0, begin);
                 let mask_end = Self::by_range(end, Self::length());
                 let mask = mask_begin | mask_end;
@@ -285,6 +289,8 @@ macro_rules! impl_Bitline {
 
             #[inline]
             fn rank_range_1(&self, begin: usize, end: usize) -> usize {
+                assert!(begin <= end, "inverted range: begin must be ≤ end");
+                assert!(end <= Self::length(), "end index out of range");
                 let mask_begin = Self::by_range(0, begin);
                 let mask_end = Self::by_range(end, Self::length());
                 let mask = mask_begin | mask_end;
@@ -802,6 +808,42 @@ mod tests {
     #[should_panic(expected = "bit index out of range")]
     fn test_access_panics_on_out_of_range_index() {
         let _ = 0b00001000_u8.access(8);
+    }
+
+    #[test]
+    #[should_panic(expected = "bit index out of range")]
+    fn test_rank_0_panics_on_out_of_range_index() {
+        let _ = 0b00001000_u8.rank_0(9);
+    }
+
+    #[test]
+    #[should_panic(expected = "bit index out of range")]
+    fn test_rank_1_panics_on_out_of_range_index() {
+        let _ = 0b00001000_u8.rank_1(9);
+    }
+
+    #[test]
+    #[should_panic(expected = "inverted range")]
+    fn test_rank_range_0_panics_on_inverted_range() {
+        let _ = 0b00001000_u8.rank_range_0(5, 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "inverted range")]
+    fn test_rank_range_1_panics_on_inverted_range() {
+        let _ = 0b00001000_u8.rank_range_1(5, 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "end index out of range")]
+    fn test_rank_range_0_panics_on_out_of_range_end() {
+        let _ = 0b00001000_u8.rank_range_0(0, 9);
+    }
+
+    #[test]
+    #[should_panic(expected = "end index out of range")]
+    fn test_rank_range_1_panics_on_out_of_range_end() {
+        let _ = 0b00001000_u8.rank_range_1(0, 9);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `assert!(index <= Self::length(), "bit index out of range")` to `rank_0` and `rank_1` implementations
- Add `assert!(begin <= end, "inverted range: begin must be ≤ end")` and `assert!(end <= Self::length(), "end index out of range")` to `rank_range_0` and `rank_range_1`
- Add `# Panics` sections to docstrings of the affected methods in `base.rs`
- Add `#[should_panic]` tests for all new panic paths

## Motivation

`rank_*` silently clamped out-of-range indices via internal `by_range` behavior,
and `rank_range_*` returned 0 for inverted ranges (begin > end), hiding programming
errors from callers. This was inconsistent with `access`, which already panics with
`"bit index out of range"`. Aligning the behavior catches misuse at the point of
error rather than producing silently wrong results.
