### PR TITLE
docs: clarify select_0/select_1/select nth parameter is 0-indexed

### DIFF
--- a/src/bitline/base.rs
+++ b/src/bitline/base.rs
@@ -505,47 +505,47 @@ pub trait Bitline {
     /// ```
     fn rank_range(&self, begin: usize, end: usize, bit: bool) -> usize;
 
-    /// Find the position where the n-th 0 appears.
-    /// If there is no n-th 0, return None.
+    /// Find the position where the `nth`-th 0 appears (`nth` is 0-indexed: 0 = first match).
+    /// If there is no such 0, return None.
     ///
     /// # Examples
     /// ```
     /// use bittersweet::bitline::{Bitline, Bitline8};
     /// let bitline = 0b00011110_u8;
-    /// assert_eq!(bitline.select_0(0), Some(0));
-    /// assert_eq!(bitline.select_0(1), Some(1));
-    /// assert_eq!(bitline.select_0(2), Some(2));
-    /// assert_eq!(bitline.select_0(3), Some(7));
+    /// assert_eq!(bitline.select_0(0), Some(0)); // first 0
+    /// assert_eq!(bitline.select_0(1), Some(1)); // second 0
+    /// assert_eq!(bitline.select_0(2), Some(2)); // third 0
+    /// assert_eq!(bitline.select_0(3), Some(7)); // fourth 0
     /// assert_eq!(bitline.select_0(4), None);
     /// ```
     fn select_0(&self, nth: usize) -> Option<usize>;
 
-    /// Find the position where the n-th 1 appears.
-    /// If there is no n-th 1, return None.
+    /// Find the position where the `nth`-th 1 appears (`nth` is 0-indexed: 0 = first match).
+    /// If there is no such 1, return None.
     ///
     /// # Examples
     /// ```
     /// use bittersweet::bitline::{Bitline, Bitline8};
     /// let bitline = 0b00011110_u8;
-    /// assert_eq!(bitline.select_1(0), Some(3));
-    /// assert_eq!(bitline.select_1(1), Some(4));
-    /// assert_eq!(bitline.select_1(2), Some(5));
-    /// assert_eq!(bitline.select_1(3), Some(6));
+    /// assert_eq!(bitline.select_1(0), Some(3)); // first 1
+    /// assert_eq!(bitline.select_1(1), Some(4)); // second 1
+    /// assert_eq!(bitline.select_1(2), Some(5)); // third 1
+    /// assert_eq!(bitline.select_1(3), Some(6)); // fourth 1
     /// assert_eq!(bitline.select_1(4), None);
     /// ```
     fn select_1(&self, nth: usize) -> Option<usize>;
 
-    /// Find the position where the n-th specified bit appears.
-    /// If there is no n-th specified bit, return None.
+    /// Find the position where the `nth`-th occurrence of `bit` appears (`nth` is 0-indexed: 0 = first match).
+    /// If there is no such bit, return None.
     ///
     /// # Examples
     /// ```
     /// use bittersweet::bitline::{Bitline, Bitline8};
     /// let bitline = 0b00011110_u8;
-    /// assert_eq!(bitline.select(0, false), Some(0));
-    /// assert_eq!(bitline.select(1, false), Some(1));
-    /// assert_eq!(bitline.select(2, false), Some(2));
-    /// assert_eq!(bitline.select(0, true), Some(3));
+    /// assert_eq!(bitline.select(0, false), Some(0)); // first 0
+    /// assert_eq!(bitline.select(1, false), Some(1)); // second 0
+    /// assert_eq!(bitline.select(2, false), Some(2)); // third 0
+    /// assert_eq!(bitline.select(0, true), Some(3));  // first 1
     /// ```
     fn select(&self, nth: usize, bit: bool) -> Option<usize>;
 }


### PR DESCRIPTION
## Summary

- `select_0`, `select_1`, and `select` doc comments used "n-th" without specifying the indexing convention.
- In natural language "n-th" typically implies 1-indexed, but the implementation is 0-indexed (`nth=0` returns the first match).
- This ambiguity can cause off-by-one bugs when callers assume 1-indexed.

## Changes

- `src/bitline/base.rs`: rewrote the first line of each doc comment to say `` `nth` is 0-indexed: 0 = first match ``.
- Added inline comments to doc-test assertions (`// first 0`, `// second 0`, etc.) so the convention is self-evident without reading the prose.

## Test plan

- [ ] `cargo test --doc` passes (doc examples unchanged in value, only comments added)
- [ ] `cargo test` passes