### PR TITLE
fix: change radius to use OR semantics instead of XOR

### DIFF
--- a/src/bitline/base.rs
+++ b/src/bitline/base.rs
@@ -104,8 +104,13 @@ pub trait Bitline {
     /// ```
     fn last_index(&self) -> Option<usize>;
 
-    /// Return the bits standing in n distance from the original starting bit.
-    /// If there is no bit set to one, return None.
+    /// Return the union of bits standing at exactly n distance from each set bit.
+    ///
+    /// For each set bit, the two neighbors at positions `bit - n` and `bit + n`
+    /// are included in the result (OR / union semantics). When multiple set bits
+    /// share a neighbor at the same position, those positions are still included
+    /// (no cancellation). `radius(0)` returns `self` because each bit is at
+    /// distance 0 from itself.
     ///
     /// When `n` is greater than or equal to the bitline length (e.g.
     /// `Bitline8::radius(8)`), no in-range neighbor exists, so the result is
@@ -117,7 +122,7 @@ pub trait Bitline {
     /// ```
     /// use bittersweet::bitline::{Bitline, Bitline8};
     /// let bitline = 0b00001000 as Bitline8;
-    /// assert_eq!(bitline.radius(0), 0b00000000);
+    /// assert_eq!(bitline.radius(0), 0b00001000);
     /// assert_eq!(bitline.radius(1), 0b00010100);
     /// assert_eq!(bitline.radius(2), 0b00100010);
     ///
@@ -127,7 +132,7 @@ pub trait Bitline {
     /// assert_eq!(bitline.radius(2), 0b00000000);
     ///
     /// let bitline = 0b00100100 as Bitline8;
-    /// assert_eq!(bitline.radius(0), 0b00000000);
+    /// assert_eq!(bitline.radius(0), 0b00100100);
     /// assert_eq!(bitline.radius(1), 0b01011010);
     /// assert_eq!(bitline.radius(2), 0b10011001);
     ///

--- a/src/bitline/base.rs
+++ b/src/bitline/base.rs
@@ -505,47 +505,47 @@ pub trait Bitline {
     /// ```
     fn rank_range(&self, begin: usize, end: usize, bit: bool) -> usize;
 
-    /// Find the position where the n-th 0 appears.
-    /// If there is no n-th 0, return None.
+    /// Find the position where the `nth`-th 0 appears (`nth` is 0-indexed: 0 = first match).
+    /// If there is no such 0, return None.
     ///
     /// # Examples
     /// ```
     /// use bittersweet::bitline::{Bitline, Bitline8};
     /// let bitline = 0b00011110_u8;
-    /// assert_eq!(bitline.select_0(0), Some(0));
-    /// assert_eq!(bitline.select_0(1), Some(1));
-    /// assert_eq!(bitline.select_0(2), Some(2));
-    /// assert_eq!(bitline.select_0(3), Some(7));
+    /// assert_eq!(bitline.select_0(0), Some(0)); // first 0
+    /// assert_eq!(bitline.select_0(1), Some(1)); // second 0
+    /// assert_eq!(bitline.select_0(2), Some(2)); // third 0
+    /// assert_eq!(bitline.select_0(3), Some(7)); // fourth 0
     /// assert_eq!(bitline.select_0(4), None);
     /// ```
     fn select_0(&self, nth: usize) -> Option<usize>;
 
-    /// Find the position where the n-th 1 appears.
-    /// If there is no n-th 1, return None.
+    /// Find the position where the `nth`-th 1 appears (`nth` is 0-indexed: 0 = first match).
+    /// If there is no such 1, return None.
     ///
     /// # Examples
     /// ```
     /// use bittersweet::bitline::{Bitline, Bitline8};
     /// let bitline = 0b00011110_u8;
-    /// assert_eq!(bitline.select_1(0), Some(3));
-    /// assert_eq!(bitline.select_1(1), Some(4));
-    /// assert_eq!(bitline.select_1(2), Some(5));
-    /// assert_eq!(bitline.select_1(3), Some(6));
+    /// assert_eq!(bitline.select_1(0), Some(3)); // first 1
+    /// assert_eq!(bitline.select_1(1), Some(4)); // second 1
+    /// assert_eq!(bitline.select_1(2), Some(5)); // third 1
+    /// assert_eq!(bitline.select_1(3), Some(6)); // fourth 1
     /// assert_eq!(bitline.select_1(4), None);
     /// ```
     fn select_1(&self, nth: usize) -> Option<usize>;
 
-    /// Find the position where the n-th specified bit appears.
-    /// If there is no n-th specified bit, return None.
+    /// Find the position where the `nth`-th occurrence of `bit` appears (`nth` is 0-indexed: 0 = first match).
+    /// If there is no such bit, return None.
     ///
     /// # Examples
     /// ```
     /// use bittersweet::bitline::{Bitline, Bitline8};
     /// let bitline = 0b00011110_u8;
-    /// assert_eq!(bitline.select(0, false), Some(0));
-    /// assert_eq!(bitline.select(1, false), Some(1));
-    /// assert_eq!(bitline.select(2, false), Some(2));
-    /// assert_eq!(bitline.select(0, true), Some(3));
+    /// assert_eq!(bitline.select(0, false), Some(0)); // first 0
+    /// assert_eq!(bitline.select(1, false), Some(1)); // second 0
+    /// assert_eq!(bitline.select(2, false), Some(2)); // third 0
+    /// assert_eq!(bitline.select(0, true), Some(3));  // first 1
     /// ```
     fn select(&self, nth: usize, bit: bool) -> Option<usize>;
 }

--- a/src/bitline/uints.rs
+++ b/src/bitline/uints.rs
@@ -107,13 +107,13 @@ macro_rules! impl_Bitline {
                 if n >= Self::BITS as usize {
                     return Self::as_empty();
                 }
-                (self << n) ^ (self >> n)
+                (self << n) | (self >> n)
             }
             #[inline]
             fn around(&self, n: usize) -> Self {
                 let upper = cmp::min(n.saturating_add(1), Self::BITS as usize);
                 let mut a = 0;
-                for m in 0..upper {
+                for m in 1..upper {
                     a |= self.radius(m);
                 }
                 a
@@ -429,7 +429,7 @@ mod tests {
 
     #[test]
     fn test_radius() {
-        assert_eq!(0b00010000_u8.radius(0), 0b00000000_u8);
+        assert_eq!(0b00010000_u8.radius(0), 0b00010000_u8);
         assert_eq!(0b00010000_u8.radius(1), 0b00101000_u8);
         assert_eq!(0b00010000_u8.radius(2), 0b01000100_u8);
         assert_eq!(0b00010000_u8.radius(3), 0b10000010_u8);
@@ -437,6 +437,8 @@ mod tests {
         assert_eq!(0b00000000_u8.radius(0), 0b00000000_u8);
         assert_eq!(0b00000000_u8.radius(1), 0b00000000_u8);
         assert_eq!(0b00000000_u8.radius(2), 0b00000000_u8);
+        // OR semantics: multi-bit inputs do not cancel at coinciding positions
+        assert_eq!(0b00100010_u8.radius(2), 0b10001000_u8);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `radius(n)` was using XOR semantics `(self << n) ^ (self >> n)`, which silently cancels bits when two set bits share a neighbor at the same shifted position (e.g. bits spaced 2n apart)
- Changed to OR semantics `(self << n) | (self >> n)` so that `radius(n)` returns the true union of all bits at exactly n distance from each set bit
- Removed stale docstring line "If there is no bit set to one, return None." (the return type is `Self`, not `Option`)
- Adjusted `around()` loop to start from `m=1` (instead of `m=0`) so that `around()` and `with_around()` public behavior is preserved — `radius(0)` now returns `self` instead of 0, but `around` intentionally excludes the original bits

## Behavior changes

| expression | before (XOR) | after (OR) |
| --- | --- | --- |
| `0b00010000_u8.radius(0)` | `0b00000000` | `0b00010000` |
| `0b00100010_u8.radius(2)` | `0b10000000` (cancellation) | `0b10001000` (both neighbors) |

`around()` and `with_around()` results are unchanged.

## Test plan

- [ ] `cargo test` passes (51 unit tests + 44 doc-tests)