### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 0.2.0 - Unreleased
+
+### Added
+
+- Add access, rank, rank range, and select operations for bitline values.
+- Add left and right rotation helpers.
+- Add Gray code conversion helpers.
+- Add bit-reversal permutation conversion helpers.
+- Add two-bit Gray code rotation.
+- Add support for building without the default `std` feature.
+
+### Changed
+
+- Split the bitline implementation into smaller modules.
+- Update `radius` to use union semantics when shifted neighborhoods overlap.
+- Document that `select_0`, `select_1`, and `select` use a zero-based `nth` argument.
+
+### Fixed
+
+- Guard bit access against out-of-range indexes.
+- Guard `radius`, `around`, and `with_around` against out-of-range shift amounts.
+- Validate rank and rank range bounds instead of silently clamping invalid inputs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bittersweet"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Yui Kitsu <kitsuyui+github@kitsuyui.com>"]
 description = "Add more intentional predicates to bitwise calcs."
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ So these operations keep zero-cost abstraction.
 
 See [docs.rs](https://docs.rs/bittersweet/latest/bittersweet/)
 
+## Release Notes
+
+See [CHANGELOG.md](CHANGELOG.md) for release notes.
+
 ## Manipulations
 
 https://docs.rs/bittersweet/latest/bittersweet/bitline/trait.Bitline.html


### PR DESCRIPTION
## Summary
- Bump the crate version to 0.2.0 for the next crates.io release
- Add release notes covering the fixes, behavior changes, and bitline API additions since 0.1.2
- Link the changelog from the README

## Tests
- cargo fmt --all -- --check
- cargo check
- cargo test
- cargo clippy -- -D warnings
- cargo build --release --all-features
- cargo check --no-default-features
- cargo publish --dry-run --allow-dirty
