### PR TITLE
fix: reject inverted bit ranges

### DIFF
--- a/src/bitline/base.rs
+++ b/src/bitline/base.rs
@@ -46,6 +46,9 @@ pub trait Bitline {
     /// use bittersweet::bitline::{Bitline, Bitline8};
     /// assert_eq!(Bitline8::by_range(2, 5), 0b00111000_u8);
     /// ```
+    /// # Panics
+    ///
+    /// Panics if `begin > end`.
     fn by_range(begin: usize, end: usize) -> Self;
 
     /// Return true if the bit is filled with zero.
@@ -309,6 +312,9 @@ pub trait Bitline {
     /// assert_eq!(bitline.range(0, 4), 0b01100000_u8);
     /// assert_eq!(bitline.range(4, 8), 0b00001100_u8);
     /// ```
+    /// # Panics
+    ///
+    /// Panics if `begin > end`.
     fn range(&self, begin: usize, end: usize) -> Self;
 
     /// Return the standing bits not included by the given range.

--- a/src/bitline/uints.rs
+++ b/src/bitline/uints.rs
@@ -56,11 +56,12 @@ macro_rules! impl_Bitline {
 
             #[inline]
             fn by_range(begin: usize, end: usize) -> Self {
+                assert!(begin <= end, "inverted range: begin must be <= end");
                 let bits_size = Self::BITS as usize;
                 let last_index = cmp::min(end, bits_size);
                 let first_index = cmp::min(begin, last_index);
                 let size = last_index - first_index;
-                if (size <= 0) {
+                if (size == 0) {
                     return Self::as_empty();
                 }
                 if (size >= bits_size) {
@@ -411,6 +412,18 @@ mod tests {
         assert_eq!(u8::by_range(3, 4), 0b00010000);
         assert_eq!(u8::by_range(0, 8), 0b11111111);
         assert_eq!(u8::by_range(0, 0), 0b00000000);
+    }
+
+    #[test]
+    #[should_panic(expected = "inverted range")]
+    fn test_by_range_panics_on_inverted_range() {
+        let _ = u8::by_range(5, 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "inverted range")]
+    fn test_range_panics_on_inverted_range() {
+        let _ = 0b11111111_u8.range(5, 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reject inverted `by_range` and `range` arguments instead of returning an empty mask.
- Document the panic contract for range helpers.
- Add regression tests for inverted range inputs.

## Testing
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`