### PR TITLE
Add non-panicking alternatives for index-based access methods

### DIFF
--- a/src/bitline/base.rs
+++ b/src/bitline/base.rs
@@ -547,6 +547,108 @@ pub trait Bitline {
     /// ```
     fn rank_range(&self, begin: usize, end: usize, bit: bool) -> usize;
 
+    /// Access the specified position in the bit sequence, returning `None` if out of range.
+    ///
+    /// This is the non-panicking counterpart of [`access`](Self::access).
+    ///
+    /// # Examples
+    /// ```
+    /// use bittersweet::bitline::{Bitline, Bitline8};
+    /// let bitline = 0b00011110_u8;
+    /// assert_eq!(bitline.try_access(0), Some(false));
+    /// assert_eq!(bitline.try_access(3), Some(true));
+    /// assert_eq!(bitline.try_access(8), None);
+    /// ```
+    fn try_access(&self, index: usize) -> Option<bool> {
+        if index < Self::length() {
+            Some(self.access(index))
+        } else {
+            None
+        }
+    }
+
+    /// Count how many times 0 appears up to the index, returning `None` if out of range.
+    ///
+    /// This is the non-panicking counterpart of [`rank_0`](Self::rank_0).
+    ///
+    /// # Examples
+    /// ```
+    /// use bittersweet::bitline::{Bitline, Bitline8};
+    /// let bitline = 0b00011110_u8;
+    /// assert_eq!(bitline.try_rank_0(2), Some(2));
+    /// assert_eq!(bitline.try_rank_0(8), Some(4));
+    /// assert_eq!(bitline.try_rank_0(9), None);
+    /// ```
+    fn try_rank_0(&self, index: usize) -> Option<usize> {
+        if index <= Self::length() {
+            Some(self.rank_0(index))
+        } else {
+            None
+        }
+    }
+
+    /// Count how many times 1 appears up to the index, returning `None` if out of range.
+    ///
+    /// This is the non-panicking counterpart of [`rank_1`](Self::rank_1).
+    ///
+    /// # Examples
+    /// ```
+    /// use bittersweet::bitline::{Bitline, Bitline8};
+    /// let bitline = 0b00011110_u8;
+    /// assert_eq!(bitline.try_rank_1(4), Some(1));
+    /// assert_eq!(bitline.try_rank_1(8), Some(4));
+    /// assert_eq!(bitline.try_rank_1(9), None);
+    /// ```
+    fn try_rank_1(&self, index: usize) -> Option<usize> {
+        if index <= Self::length() {
+            Some(self.rank_1(index))
+        } else {
+            None
+        }
+    }
+
+    /// Count how many times 0 appears in the range, returning `None` if the range is invalid.
+    ///
+    /// Returns `None` if `begin > end` or `end > length`. This is the non-panicking counterpart
+    /// of [`rank_range_0`](Self::rank_range_0).
+    ///
+    /// # Examples
+    /// ```
+    /// use bittersweet::bitline::{Bitline, Bitline8};
+    /// let bitline = 0b00011110_u8;
+    /// assert_eq!(bitline.try_rank_range_0(0, 4), Some(3));
+    /// assert_eq!(bitline.try_rank_range_0(5, 3), None);
+    /// assert_eq!(bitline.try_rank_range_0(0, 9), None);
+    /// ```
+    fn try_rank_range_0(&self, begin: usize, end: usize) -> Option<usize> {
+        if begin <= end && end <= Self::length() {
+            Some(self.rank_range_0(begin, end))
+        } else {
+            None
+        }
+    }
+
+    /// Count how many times 1 appears in the range, returning `None` if the range is invalid.
+    ///
+    /// Returns `None` if `begin > end` or `end > length`. This is the non-panicking counterpart
+    /// of [`rank_range_1`](Self::rank_range_1).
+    ///
+    /// # Examples
+    /// ```
+    /// use bittersweet::bitline::{Bitline, Bitline8};
+    /// let bitline = 0b00011110_u8;
+    /// assert_eq!(bitline.try_rank_range_1(0, 4), Some(1));
+    /// assert_eq!(bitline.try_rank_range_1(5, 3), None);
+    /// assert_eq!(bitline.try_rank_range_1(0, 9), None);
+    /// ```
+    fn try_rank_range_1(&self, begin: usize, end: usize) -> Option<usize> {
+        if begin <= end && end <= Self::length() {
+            Some(self.rank_range_1(begin, end))
+        } else {
+            None
+        }
+    }
+
     /// Find the position where the `nth`-th 0 appears (`nth` is 0-indexed: 0 = first match).
     /// If there is no such 0, return None.
     ///

--- a/src/bitline/uints.rs
+++ b/src/bitline/uints.rs
@@ -862,6 +862,54 @@ mod tests {
     }
 
     #[test]
+    fn test_try_access() {
+        let bitline = 0b00011110_u8;
+        assert_eq!(bitline.try_access(0), Some(false));
+        assert_eq!(bitline.try_access(3), Some(true));
+        assert_eq!(bitline.try_access(7), Some(false));
+        assert_eq!(bitline.try_access(8), None);
+        assert_eq!(bitline.try_access(100), None);
+    }
+
+    #[test]
+    fn test_try_rank_0() {
+        let bitline = 0b00011110_u8;
+        assert_eq!(bitline.try_rank_0(0), Some(0));
+        assert_eq!(bitline.try_rank_0(2), Some(2));
+        assert_eq!(bitline.try_rank_0(8), Some(4));
+        assert_eq!(bitline.try_rank_0(9), None);
+    }
+
+    #[test]
+    fn test_try_rank_1() {
+        let bitline = 0b00011110_u8;
+        assert_eq!(bitline.try_rank_1(0), Some(0));
+        assert_eq!(bitline.try_rank_1(4), Some(1));
+        assert_eq!(bitline.try_rank_1(8), Some(4));
+        assert_eq!(bitline.try_rank_1(9), None);
+    }
+
+    #[test]
+    fn test_try_rank_range_0() {
+        let bitline = 0b00011110_u8;
+        assert_eq!(bitline.try_rank_range_0(0, 4), Some(3));
+        assert_eq!(bitline.try_rank_range_0(0, 8), Some(4));
+        assert_eq!(bitline.try_rank_range_0(3, 5), Some(0));
+        assert_eq!(bitline.try_rank_range_0(5, 3), None);
+        assert_eq!(bitline.try_rank_range_0(0, 9), None);
+    }
+
+    #[test]
+    fn test_try_rank_range_1() {
+        let bitline = 0b00011110_u8;
+        assert_eq!(bitline.try_rank_range_1(0, 4), Some(1));
+        assert_eq!(bitline.try_rank_range_1(0, 8), Some(4));
+        assert_eq!(bitline.try_rank_range_1(3, 7), Some(4));
+        assert_eq!(bitline.try_rank_range_1(5, 3), None);
+        assert_eq!(bitline.try_rank_range_1(0, 9), None);
+    }
+
+    #[test]
     fn test_rank_operations() {
         // rank(index, true) is equivalent to rank_1(index)
         // rank(index, false) is equivalent to rank_0(index)


### PR DESCRIPTION
## What

Add five new default trait methods to `Bitline`:

- `try_access(index)` → `Option<bool>`
- `try_rank_0(index)` → `Option<usize>`
- `try_rank_1(index)` → `Option<usize>`
- `try_rank_range_0(from, to)` → `Option<usize>`
- `try_rank_range_1(from, to)` → `Option<usize>`

Each returns `None` when the index (or range) is out of range, instead of panicking. Implementations are in `src/bitline/base.rs` as default methods on the `Bitline` trait.

## Why

`select_0` and `select_1` already return `Option` for not-found results. However, the index-based methods (`access`, `rank_0`, `rank_1`, `rank_range_0`, `rank_range_1`) only had panicking versions, forcing callers to perform manual bounds-checking before every call.

This fills that gap, following the same `get`-vs-`index` pattern used in the standard library (`Vec::get` vs `Vec::index`). Callers can now handle out-of-range inputs safely without pre-validation boilerplate.

## Tests

Five new unit tests added in `src/bitline/uints.rs`, covering in-range values, boundary values, and out-of-range inputs for each new method.
