### PR TITLE
docs: add cross-references between matrix and bitline modules

### DIFF
--- a/src/bitline/mod.rs
+++ b/src/bitline/mod.rs
@@ -1,3 +1,7 @@
+//! Bit-manipulation predicates and operations for integer primitives.
+//!
+//! See also: [`crate::matrix`] for bit matrix transposition over the same integer types.
+
 mod base;
 mod uints;
 // re-export

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,3 +1,7 @@
+//! Bit matrix transposition operations for integer primitive arrays.
+//!
+//! See also: [`crate::bitline`] for bit-manipulation predicates over the same integer types.
+
 #[inline]
 pub fn transpose8x8_u64(n: u64) -> u64 {
     let m = (n ^ (n >> 7)) & 0x00aa00aa00aa00aa;


### PR DESCRIPTION
## Summary

`src/matrix.rs` and `src/bitline/` operated on the same integer primitive
types (`u8`/`u16`/`u32`/`u64`/`u128`) but were completely disconnected in
the reference graph. A library user following the `bitline` module docs had
no path to discover the `matrix` module, and vice versa.

## Changes

Add module-level rustdoc comments with `See also:` intra-doc links to both
modules, connecting them bidirectionally in the generated documentation:

- `src/bitline/mod.rs`: add description and `See also: crate::matrix`
- `src/matrix.rs`: add description and `See also: crate::bitline`

## Verification

- `cargo fmt`: clean
- `cargo test`: 49 passed, 0 failed
- `cargo clippy`: no warnings
