### PR TITLE
Add workflow concurrency controls

### DIFF
--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -10,6 +10,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   publish:
     permissions:

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,11 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
## Summary
- add top-level concurrency controls to the test and coverage workflows
- add concurrency to the crate publishing workflow while preserving release publish runs

## Verification
- actionlint .github/workflows/cratesio-publish.yml .github/workflows/octocov.yml .github/workflows/test.yml
- cargo fmt --all -- --check
- cargo check
- cargo test
- cargo clippy -- -D warnings
- cargo build
- git diff --check
- implement-validator: overall: pass
