### PR TITLE
docs: complete Bitline manipulations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ https://docs.rs/bittersweet/latest/bittersweet/bitline/trait.Bitline.html
 
 - `as_empty`
 - `as_full`
+- `mask_01`
+- `mask_10`
 - `by_range`
 - `bytes_length`
 - `length`
@@ -94,6 +96,21 @@ https://docs.rs/bittersweet/latest/bittersweet/bitline/trait.Bitline.html
 - `bit_reversal_permutation_to_bin`
 - `bin_to_bit_reversal_permutation`
 - `two_bits_gray_code_rotation`
+- `access`
+- `rank_0`
+- `rank_1`
+- `rank`
+- `rank_range_0`
+- `rank_range_1`
+- `rank_range`
+- `try_access`
+- `try_rank_0`
+- `try_rank_1`
+- `try_rank_range_0`
+- `try_rank_range_1`
+- `select_0`
+- `select_1`
+- `select`
 
 ## License
 


### PR DESCRIPTION
## Summary
- Update the README Manipulations index to include all public `Bitline` methods.
- Add the mask, access, rank, try-rank, and select APIs that were missing from the list.

## Validation
- `cargo check`
- `cargo test`
- `cargo build`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `typos`
- `git diff --check`
