### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,24 @@ https://docs.rs/bittersweet/latest/bittersweet/bitline/trait.Bitline.html
 - `select_1`
 - `select`
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `cargo fmt --all -- --check` and `cargo clippy -- -D warnings`
+- **pre-push**: the above plus `cargo test`
+
+CI still runs the full suite (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 ## License
 
 BSD-3-Clause

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy -- -D warnings
+
+pre-push:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy -- -D warnings
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo test


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` to mirror the same `cargo fmt`, `cargo clippy`, and `cargo test` checks that CI runs, so issues are caught locally before they reach CI.
- Add a `## Development` section to `README.md` explaining how to install and use the hooks.
- CI workflows are left completely unchanged.

## Changes

- **`lefthook.yml`** (new): defines `pre-commit` (fmt + clippy) and `pre-push` (fmt + clippy + test) hooks using the exact flags from `.github/workflows/test.yml`.
- **`README.md`**: new `## Development` section inserted before `## License`, documenting `lefthook install` and the hook behaviour.

## Verification

All mirrored checks were verified to pass on current code before committing:

- `cargo fmt --all -- --check` — passed
- `cargo clippy -- -D warnings` — passed
- `cargo test` — passed (64 unit tests + 49 doc-tests)

The pre-commit hook fired during the commit and passed; the pre-push hook fired during push and passed.

## Notes

- Requires [`lefthook`](https://lefthook.dev/) on `PATH` and `cargo` (Rust stable toolchain).
- Hooks are opt-in: contributors who do not run `lefthook install` are unaffected.
