### PR TITLE
Fix CHANGELOG 0.2.0 entry: replace Unreleased marker with release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.0 - Unreleased
+## 0.2.0 - 2026-05-14
 
 ### Added
 


### PR DESCRIPTION
## Summary

Update the `CHANGELOG.md` entry for `0.2.0` to replace the `Unreleased`
marker with the actual release date `2026-05-14`.

## Why

`v0.2.0` was released on 2026-05-14 (tagged `d4238f1`, GitHub release
published). The `## 0.2.0 - Unreleased` marker was never updated after the
release, which means:

- Readers of the changelog cannot tell when this version was released.
- The next round of entries for an upcoming version could be mixed into
  what is already a released section.

This is a one-line fix following the [Keep a Changelog](https://keepachangelog.com/)
convention of updating `Unreleased` to the release date when publishing.

## Verification

- `cargo clippy --all-targets --all-features` — 0 warnings
- One-line change; no logic affected.
