### PR TITLE
Panic when bit range end exceeds bitline length

### DIFF
--- a/src/bitline/base.rs
+++ b/src/bitline/base.rs
@@ -48,7 +48,7 @@ pub trait Bitline {
     /// ```
     /// # Panics
     ///
-    /// Panics if `begin > end`.
+    /// Panics if `begin > end` or if `end` is greater than the bitline length.
     fn by_range(begin: usize, end: usize) -> Self;
 
     /// Return true if the bit is filled with zero.
@@ -314,7 +314,7 @@ pub trait Bitline {
     /// ```
     /// # Panics
     ///
-    /// Panics if `begin > end`.
+    /// Panics if `begin > end` or if `end` is greater than the bitline length.
     fn range(&self, begin: usize, end: usize) -> Self;
 
     /// Return the standing bits not included by the given range.

--- a/src/bitline/uints.rs
+++ b/src/bitline/uints.rs
@@ -58,8 +58,9 @@ macro_rules! impl_Bitline {
             fn by_range(begin: usize, end: usize) -> Self {
                 assert!(begin <= end, "inverted range: begin must be <= end");
                 let bits_size = Self::BITS as usize;
-                let last_index = cmp::min(end, bits_size);
-                let first_index = cmp::min(begin, last_index);
+                assert!(end <= bits_size, "end index out of range");
+                let last_index = end;
+                let first_index = begin;
                 let size = last_index - first_index;
                 if (size == 0) {
                     return Self::as_empty();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16,6 +16,18 @@ fn bitline_by_range() {
 }
 
 #[test]
+#[should_panic(expected = "end index out of range")]
+fn bitline_by_range_panics_when_end_exceeds_length() {
+    let _: u8 = Bitline::by_range(0, 9);
+}
+
+#[test]
+#[should_panic(expected = "end index out of range")]
+fn bitline_range_panics_when_end_exceeds_length() {
+    let _ = 0b11111111_u8.range(0, 9);
+}
+
+#[test]
 fn bitline_first_and_last_index() {
     let b = 0b00111000_u8;
     assert_eq!(b.first_index(), Some(2));


### PR DESCRIPTION
## Summary
- make `by_range` reject range ends beyond the bitline length instead of silently clamping
- update `by_range` and `range` panic docs to match the existing range APIs
- add panic coverage for out-of-bounds range ends through both public entry points

## Verification
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo build --release --all-features`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `typos src/bitline/base.rs src/bitline/uints.rs tests/integration_test.rs .github/workflows`
- `git diff --check`
- `check-pr-collateral`: clean
- `implement-validator`: overall pass
