### PR TITLE
ci: add timeout-minutes to all workflow jobs

### DIFF
--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   octocov:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -25,6 +26,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -36,6 +38,7 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -47,6 +50,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -58,6 +62,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -67,6 +72,7 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

Add `timeout-minutes: 30` to all 8 workflow jobs that run inline steps.

Without an explicit timeout, GitHub Actions uses the default of 360 minutes (6 hours).
A hung `cargo build`, `cargo test`, or network wait can occupy a runner for the entire
default window, increasing billing and delaying feedback.

## Changes

| File | Jobs updated |
|------|-------------|
| `.github/workflows/test.yml` | check, test, format, lint, build, coverage (6 jobs) |
| `.github/workflows/octocov.yml` | octocov (1 job) |
| `.github/workflows/cratesio-publish.yml` | publish (1 job) |

Jobs using reusable workflows (`gitignore-in.yml`, `happy.yml`, `spellcheck.yml`) are excluded —
timeout applies within the callee workflow, not at the call site.

## Why 30 minutes

Normal run times for this repo are well under 10 minutes with caching.
30 minutes provides comfortable headroom for cold cache builds while catching
genuine hangs well before the 360-minute default.

## Verification

No Rust source code changes — the diff only updates workflow YAML files.
