### PR TITLE
chore: enforce 80% coverage threshold in octocov

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,6 +2,7 @@
 coverage:
   paths:
     - coverage.lcov
+  acceptable: 80%
 codeToTestRatio:
   code:
     - "src/**/*.rs"


### PR DESCRIPTION
`.octocov.yml` reports coverage diffs on PRs and stores coverage history, but has no `coverage.acceptable` threshold. Without it, CI passes even if coverage drops to 0%.

## Change

Add `acceptable: 80%` to the `coverage:` block in `.octocov.yml`. octocov will now fail the check if statement coverage falls below 80%.

## Why 80%

Current coverage is 100% (confirmed from recent CI runs). 80% is a conservative starting threshold that:
- Catches significant regressions (any drop below 80% from 100% is substantial)
- Leaves headroom for new uncovered branches without immediately blocking CI
- Aligns with common industry baselines for Rust libraries

The threshold can be raised once the team is confident in the coverage baseline.

## Verification

YAML syntax is valid. No Rust code was changed. The `clippy` and `cargo check` gates are unaffected. The threshold will be exercised by the octocov CI step on the next push.
