### PR TITLE
chore: add workflow to verify merge automation repo settings

### DIFF
--- a/.github/workflows/repo-settings.yml
+++ b/.github/workflows/repo-settings.yml
@@ -1,0 +1,60 @@
+name: Verify repository settings
+
+on:
+  schedule:
+    # Run quarterly: 1st day of Jan/Apr/Jul/Oct at 09:00 UTC
+    - cron: '0 9 1 1,4,7,10 *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify merge automation settings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repository settings
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          settings=$(gh api "repos/${REPO}" \
+            --jq '{
+              allow_auto_merge,
+              allow_update_branch,
+              delete_branch_on_merge,
+              allow_squash_merge,
+              allow_rebase_merge
+            }')
+
+          echo "Current settings:"
+          echo "$settings" | jq .
+
+          failures=0
+
+          check() {
+            local field="$1"
+            local expected="$2"
+            local actual
+            actual=$(echo "$settings" | jq -r ".$field")
+            if [ "$actual" != "$expected" ]; then
+              echo "FAIL: $field expected=$expected actual=$actual"
+              failures=$((failures + 1))
+            else
+              echo "OK:   $field=$actual"
+            fi
+          }
+
+          check allow_auto_merge     true
+          check allow_update_branch  true
+          check delete_branch_on_merge true
+          check allow_squash_merge   true
+          check allow_rebase_merge   true
+
+          if [ "$failures" -gt 0 ]; then
+            echo ""
+            echo "${failures} setting(s) have drifted from the expected state."
+            echo "Update them via: gh api repos/${REPO} --method PATCH --field <field>=<value>"
+            exit 1
+          fi


### PR DESCRIPTION
Three merge-automation settings were disabled, causing friction for automated workflows and contributors:

| Setting | Before | After |
|---|---|---|
| `allow_auto_merge` | `false` | `true` |
| `allow_update_branch` | `false` | `true` |
| `delete_branch_on_merge` | `false` | `true` |
| `allow_squash_merge` | `false` | `true` |
| `allow_rebase_merge` | `false` | `true` |

The settings have already been applied directly via `gh api repos/kitsuyui/bittersweet --method PATCH`.

## Change in this PR

Adds `.github/workflows/repo-settings.yml`: a quarterly-scheduled workflow that checks the five settings listed above and fails if any have drifted from the intended state. `workflow_dispatch` allows manual re-runs.

The workflow documents the intended configuration and prevents future drift without requiring any external app (probot/settings is not installed on this repo).

## Note on merge strategy alignment

The ruleset `default-branch-baseline` already lists `merge`, `squash`, and `rebase` as `allowed_merge_methods`. Enabling `allow_squash_merge` and `allow_rebase_merge` at the repository level now matches the ruleset, resolving the previous inconsistency.
