### PR TITLE
Document no-std usage and crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Yui Kitsu <kitsuyui+github@kitsuyui.com>"]
 description = "Add more intentional predicates to bitwise calcs."
 license = "BSD-3-Clause"
 edition = "2021"
+repository = "https://github.com/kitsuyui/bittersweet"
+keywords = ["bitwise", "bit-manipulation", "bitmap"]
 categories = ["no-std"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ $ cargo add bittersweet
 
 Or you can add this to your `Cargo.toml` manually.
 
+For `no_std` environments, disable the default `std` feature:
+
+```toml
+[dependencies]
+bittersweet = { version = "0.2", default-features = false }
+```
+
+The crate enables `std` by default. With `default-features = false`, the core
+bitline traits and integer implementations remain available without linking the
+standard library. Re-enable `std` when you need APIs gated behind that feature.
+
 ### Example
 
 ```rust


### PR DESCRIPTION
## Summary
- add repository and keyword metadata for the published crate
- document how to use bittersweet with default features disabled in no-std builds

## Verification
- `cargo metadata --no-deps --format-version 1`
- `cargo check`
- `cargo check --no-default-features`
- `cargo test`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo build --release --all-features`
- `git diff --check`
- `typos Cargo.toml README.md`
- `actionlint -color .github/workflows/*.yml`
- `collateral check: clean`
- `implement-validator: overall pass`
