### PR TITLE
chore: add keywords and repository to Cargo.toml for discoverability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ description = "Add more intentional predicates to bitwise calcs."
 license = "BSD-3-Clause"
 edition = "2021"
 categories = ["no-std"]
+keywords = ["bitwise", "bit-operations", "predicates"]
+repository = "https://github.com/kitsuyui/bittersweet"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]


### PR DESCRIPTION
## Summary

Adds missing metadata to `Cargo.toml` to improve discoverability:

- `keywords = ["bitwise", "bit-operations", "predicates"]` — enables crates.io keyword search
- `repository = "https://github.com/kitsuyui/bittersweet"` — links the crates.io page to the source

GitHub repository topics (`rust`, `bitwise`, `library`, `no-std`) were also set
via the GitHub API to enable GitHub Explore/Trending and topic-based search.

## Testing

- `cargo fmt --all` — no changes
- `cargo clippy -- -D warnings` — clean
- `cargo test` — 49 tests pass
- No collateral findings
