### PR TITLE
docs: document MSB-first bit indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ See [docs.rs](https://docs.rs/bittersweet/latest/bittersweet/)
 
 See [CHANGELOG.md](CHANGELOG.md) for release notes.
 
+## Bit indexing
+
+Bitline position APIs use MSB-first indexing. Index `0` is the most significant
+bit, shown at the left edge of a binary literal or `bit_repr()`. The last valid
+index is the least significant bit.
+
+Range arguments use the same ordering and follow Rust's half-open convention:
+`[begin, end)`. For example, `0b10000000_u8.access(0)` is `true`, and
+`Bitline8::by_range(2, 5)` returns `0b00111000_u8`.
+
 ## Manipulations
 
 https://docs.rs/bittersweet/latest/bittersweet/bitline/trait.Bitline.html

--- a/src/bitline/base.rs
+++ b/src/bitline/base.rs
@@ -7,6 +7,12 @@ use std::prelude::v1::*;
 
 use core::option::Option;
 
+/// Bit-manipulation predicates and operations over a fixed-width bit sequence.
+///
+/// Position arguments use MSB-first indexing: index `0` is the most significant
+/// bit, shown at the left edge of a binary literal or `bit_repr()`. Index
+/// `Self::length() - 1` is the least significant bit. Range arguments use the
+/// same ordering and follow Rust's half-open convention: `[begin, end)`.
 pub trait Bitline {
     /// Return the bits all set to 0
     /// # Examples
@@ -40,7 +46,10 @@ pub trait Bitline {
     /// ```
     fn mask_10() -> Self;
 
-    /// Return the bits standing in the given range.
+    /// Return the bits standing in the given half-open MSB-first range.
+    ///
+    /// `begin` is included and `end` is excluded.
+    ///
     /// # Examples
     /// ```
     /// use bittersweet::bitline::{Bitline, Bitline8};
@@ -431,7 +440,9 @@ pub trait Bitline {
     /// ```
     fn two_bits_gray_code_rotation(&self) -> Self;
 
-    /// Access the specified position in the bit sequence and get the value of the bit.
+    /// Access the specified MSB-first position and get the value of the bit.
+    ///
+    /// Index `0` is the most significant bit.
     ///
     /// # Examples
     /// ```
@@ -442,6 +453,7 @@ pub trait Bitline {
     /// assert_eq!(bitline.access(2), false);
     /// assert_eq!(bitline.access(3), true);
     /// assert_eq!(bitline.access(4), true);
+    /// assert_eq!(0b10000000_u8.access(0), true);
     /// ```
     ///
     /// # Panics
@@ -449,7 +461,10 @@ pub trait Bitline {
     /// Panics if `index` is greater than or equal to the bitline length.
     fn access(&self, index: usize) -> bool;
 
-    /// Count how many times 0 appears up to the index (i-th) position.
+    /// Count how many times 0 appears before the given MSB-first index.
+    ///
+    /// The count covers the half-open range `[0, index)`, so `index == 0`
+    /// always returns `0` and `index == Self::length()` counts the whole bitline.
     ///
     /// # Examples
     /// ```
@@ -466,7 +481,10 @@ pub trait Bitline {
     /// Panics if `index` is greater than the bitline length.
     fn rank_0(&self, index: usize) -> usize;
 
-    /// Count how many times 1 appears up to the index (i-th) position.
+    /// Count how many times 1 appears before the given MSB-first index.
+    ///
+    /// The count covers the half-open range `[0, index)`, so `index == 0`
+    /// always returns `0` and `index == Self::length()` counts the whole bitline.
     ///
     /// # Examples
     /// ```
@@ -488,7 +506,10 @@ pub trait Bitline {
     /// Panics if `index` is greater than the bitline length.
     fn rank_1(&self, index: usize) -> usize;
 
-    /// Count how many times specified bit appears up to the index (i-th) position.
+    /// Count how many times the specified bit appears before the given MSB-first index.
+    ///
+    /// The count covers the half-open range `[0, index)`, so `index == 0`
+    /// always returns `0` and `index == Self::length()` counts the whole bitline.
     ///
     /// # Examples
     /// ```
@@ -501,7 +522,9 @@ pub trait Bitline {
     /// ```
     fn rank(&self, index: usize, bit: bool) -> usize;
 
-    /// Count how many times 0 appears between the begin (i-th) and the end (j-th) positions.
+    /// Count how many times 0 appears in the given half-open MSB-first range.
+    ///
+    /// `begin` is included and `end` is excluded.
     ///
     /// # Examples
     /// ```
@@ -517,7 +540,9 @@ pub trait Bitline {
     /// Panics if `begin > end` or if `end` is greater than the bitline length.
     fn rank_range_0(&self, begin: usize, end: usize) -> usize;
 
-    /// Count how many times 1 appears between the begin (i-th) and the end (j-th) positions.
+    /// Count how many times 1 appears in the given half-open MSB-first range.
+    ///
+    /// `begin` is included and `end` is excluded.
     ///
     /// # Examples
     /// ```
@@ -534,7 +559,9 @@ pub trait Bitline {
     /// Panics if `begin > end` or if `end` is greater than the bitline length.
     fn rank_range_1(&self, begin: usize, end: usize) -> usize;
 
-    /// Count how many times specified bit appears between the begin (i-th) and the end (j-th) positions.
+    /// Count how many times the specified bit appears in the given half-open MSB-first range.
+    ///
+    /// `begin` is included and `end` is excluded.
     ///
     /// # Examples
     /// ```

--- a/src/bitline/mod.rs
+++ b/src/bitline/mod.rs
@@ -1,5 +1,9 @@
 //! Bit-manipulation predicates and operations for integer primitives.
 //!
+//! Position and range APIs use MSB-first indexing: position `0` is the most
+//! significant bit, shown at the left edge of a binary literal or `bit_repr()`.
+//! The last valid position is the least significant bit.
+//!
 //! See also: [`crate::matrix`] for bit matrix transposition over the same integer types.
 
 mod base;


### PR DESCRIPTION
## Summary
- document that Bitline position APIs use MSB-first indexing
- clarify that rank and range APIs use half-open `[begin, end)` ranges in the same order
- add an `access` example where MSB-first and LSB-first interpretations differ

## Verification
- `implement-validator`: overall pass
- `cargo check`
- `cargo test`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo build --release --all-features`
- `typos src README.md Cargo.toml CHANGELOG.md tests`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `cargo tree --duplicates` — no duplicate dependencies
- `check-pr-collateral`: clean
