### PR TITLE
test: extend gray code roundtrip test to cover u8 max value (255)

### DIFF
--- a/src/bitline/uints.rs
+++ b/src/bitline/uints.rs
@@ -714,7 +714,7 @@ mod tests {
 
     #[test]
     fn test_to_gray_code_and_from_gray_code_is_reversible() {
-        for bitline in 0..255 {
+        for bitline in 0..=255 {
             let bitline = bitline as u8;
             assert_eq!(bitline.gray_code_to_bin().bin_to_gray_code(), bitline);
             assert_eq!(bitline.bin_to_gray_code().gray_code_to_bin(), bitline);


### PR DESCRIPTION
## Summary

`test_to_gray_code_and_from_gray_code_is_reversible` used an exclusive upper bound `0..255`, which skipped value 255 in the round-trip verification.

- Change `0..255` → `0..=255` in the reversibility test so all 256 u8 values are covered.
- The adjacent `test_gray_code_distance` retains `0..255` intentionally: it computes `num + 1` inside the loop, which would overflow `u8` at 255. That bound is correct as-is.

## Test plan

- `cargo test` passes with all 49 tests including `test_to_gray_code_and_from_gray_code_is_reversible` now verifying 255.
- `cargo clippy -- -D warnings`: clean.
- `cargo fmt --all`: no formatting changes.
- `cargo audit`: no known vulnerabilities.
